### PR TITLE
django_back 수정

### DIFF
--- a/full_model.py
+++ b/full_model.py
@@ -1,0 +1,107 @@
+from django.db import models
+from django.contrib.auth.models import AbstractUser
+import uuid
+
+
+# ✅ 사용자 모델
+class User(AbstractUser):
+    user_code = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False)
+    user_id = models.BigIntegerField(blank=True, null=False)
+    user_pw = models.CharField(max_length=200, blank=True, null=False)
+    user_nickname = models.CharField(max_length=20, blank=True, null=True)
+    user_privilege = models.BooleanField(default=False)
+    user_created_date = models.DateTimeField(auto_now_add=True)
+    user_left_date = models.DateTimeField(blank=True, null=True)
+
+    def __str__(self):
+        return self.username
+
+
+# ✅ 로그인 로그
+class LoginLog(models.Model):
+    log_id = models.AutoField(primary_key=True)
+    user_code = models.ForeignKey(User, on_delete=models.CASCADE)
+    user_ip = models.CharField(max_length=50, blank=True, null=False)
+    login_time = models.DateTimeField(auto_now_add=True)
+    logout_time = models.DateTimeField(blank=True, null=True)
+
+    def __str__(self):
+        return f'{self.user.username} - {self.login_time}'
+
+
+# ✅ 팀 모델
+class Team(models.Model):
+    team_id = models.AutoField(primary_key=True)
+    team_name = models.CharField(max_length=50)
+
+    def __str__(self):
+        return self.team_name
+
+
+# ✅ 팀 활동 로그
+class TeamLog(models.Model):
+    team_log_id = models.AutoField(primary_key=True)
+    user_code = models.ForeignKey(User, on_delete=models.CASCADE)
+    team_id = models.ForeignKey(Team, on_delete=models.CASCADE)
+    action_time = models.DateTimeField(auto_now_add=True)
+
+    def __str__(self):
+        return f'{self.team.team_name} - {self.user.username} - {self.action}'
+
+
+# ✅ 템플릿
+class Template(models.Model):
+    template_id = models.AutoField(primary_key=True)
+    user_code = models.ForeignKey(User, on_delete=models.CASCADE, null=True, blank=True)
+    tech_name = models.CharField(max_length=200)
+    tech_description = models.TextField()
+    problem_solved = models.TextField()
+    tech_differentiation = models.TextField()
+    application_field = models.TextField(blank=True, null=True)
+    components_functions = models.TextField()
+    implementation_example = models.TextField()
+    drawing_description = models.TextField(blank=True, null=True)
+    application_info = models.CharField(max_length=100)
+    inventor_info = models.CharField(max_length=100)
+    date = models.DateTimeField(auto_now_add=True)
+    template_title = models.CharField(max_length=50)
+
+    def __str__(self):
+        return self.template_title
+
+
+# ✅ 드래프트
+class Draft(models.Model):
+    draft_id = models.AutoField(primary_key=True)
+    template = models.ForeignKey(Template, on_delete=models.CASCADE)
+    version = models.CharField(max_length=8, default='v0')
+    draft_name = models.CharField(max_length=30)
+    create_draft = models.TextField()
+    create_time = models.DateTimeField(auto_now_add=True)
+    draft_title = models.CharField(max_length=100, blank=True, null=True)
+
+    def __str__(self):
+        return self.draft_name
+
+
+# ✅ 도면 이미지
+class Image(models.Model):
+    image_id = models.AutoField(primary_key=True)
+    template = models.ForeignKey(Template, on_delete=models.CASCADE)
+    image_url = models.CharField(max_length=3000)
+    image_name = models.CharField(max_length=3000)
+    image_extension = models.CharField(max_length=10)
+
+    def __str__(self):
+        return self.image_name
+
+
+# ✅ 초안 평가
+class Evaluation(models.Model):
+    eval_id = models.AutoField(primary_key=True)
+    draft = models.ForeignKey(Draft, on_delete=models.CASCADE)
+    content = models.TextField()
+    created_at = models.DateTimeField(auto_now_add=True)
+
+    def __str__(self):
+        return f'평가 {self.eval_id} - {self.draft.draft_name}'


### PR DESCRIPTION
## 📌 PR 제목
[FEAT] User, Team, TeamLog, Evaluation 모델 추가 및 수정 (ERD 기반 구조 반영)

## 변경 사항
- `User` 모델을 Django `AbstractUser` 기반으로 커스터마이징하고, UUID primary key 필드(`user_code`) 추가
- `Team` 모델 생성: 부서(소속팀) 개념 도입, 부서 ID 및 명칭 정의
- `TeamLog` 모델 생성: 사용자 소속 부서 변경/기록 이력 저장용
- `Evaluation` 모델 생성: 초안에 대한 평가 내용 및 작성 일시 저장
- 위 모델들 간 ForeignKey 연관관계 설정 (User ↔ Team, Draft ↔ Evaluation 등)
- ERD 기반 데이터 흐름을 Django ORM 상에서 충실히 반영
![image](https://github.com/user-attachments/assets/cad0f534-389b-4c7d-b765-bfe2b4456bff)

## 테스트
- [x] 로컬에서 테스트 완료
- [x] 기존 테스트 통과


## 관련 이슈
Closes #42

## 기타
- 앱 분리 구조를 다음과 같이 설정:
  - `accounts`: 사용자 및 팀, 로그 관련 모델
  - `ai_assist`: 템플릿/초안/도면/평가 관련 기능
- 이후 관리자 페이지 및 REST API에 맞춰 직렬화기/폼도 업데이트 예정

---

### 체크리스트
- [x] 코드가 깔끔하게 작성되었나요?
- [x] 문서화는 충분히 되었나요?
- [x] 불필요한 커밋/파일은 제거했나요?

---

### 리뷰어에게 바라는 점 
- 모델 간 관계 설정이 명확한지 확인 부탁드립니다.
- 디렉토리 및 앱 구조가 요구사항에 부합하는지 검토 부탁드립니다.
- ERD 기반 설계가 충분히 반영되었는지 확인해주시면 감사하겠습니다.

### 추가 안내 사항 
- 전체 코드를 full_model에 작성해 놓았습니다. 각자 필요한 부분을 가져가서 사용하시면 됩니다.  

감사합니다!
