### PR TITLE
Feat:new_rag

### DIFF
--- a/RAG/build_index.py
+++ b/RAG/build_index.py
@@ -1,0 +1,130 @@
+#!/usr/bin/env python
+# build_index.py
+"""
+vectordb → FAISS 인덱스 빌드 (GPU 가속, OPQ+IVF+HNSW+PQ)
+– embedding_complete.done 체크
+– 샘플링 기반 train
+– nlist, pq_bytes, nprobe, hnsw 층 등 튜닝 옵션
+"""
+
+import os
+import argparse
+import warnings
+from pathlib import Path
+
+import numpy as np
+import faiss
+
+# ──────────────── 기본 파라미터 ────────────────
+DEFAULT_NLIST     = 1280      # IVF 클러스터 수(변경 가능) -> 1024
+DEFAULT_PQ_BYTES  = 64       # PQ 코딩 바이트 수
+DEFAULT_NPROBE    = 32       # 검색 시 탐색할 IVF 셀 수
+MIN_TRAIN_VECS    = 50000    # 최소 훈련용 벡터 수
+MAX_SAMPLE_VECS   = 500000  # train 시 최대 샘플링 벡터 수
+HNSW_M            = 64         # HNSW 그래프 연결 수
+
+def parse_args():
+    p = argparse.ArgumentParser()
+    p.add_argument("--out_dir",    default="embeddb",
+                   help="벡터(.npy) 파일들과 embedding_complete.done 이 있는 디렉터리")
+    p.add_argument("--nlist",      type=int,   default=DEFAULT_NLIST,
+                   help="IVF 클러스터 수 (default: %(default)s)")
+    p.add_argument("--pq_bytes",   type=int,   default=DEFAULT_PQ_BYTES,
+                   help="PQ 인코딩 바이트 수 (default: %(default)s)")
+    p.add_argument("--nprobe",     type=int,   default=DEFAULT_NPROBE,
+                   help="검색 시 탐색할 IVF 셀 수 (default: %(default)s)")
+    p.add_argument("--use_gpu",    action="store_true",
+                   help="GPU 에서 train/add 를 수행합니다")
+    p.add_argument("--no_hnsw",    action="store_true",
+                   help="HNSW 레이어를 생략합니다")
+    return p.parse_args()
+
+def main():
+    args = parse_args()
+    out = Path(args.out_dir)
+
+    # 1) embedding 완료 플래그 확인
+    if not (out/"embedding_complete.done").exists():
+        print("❌ embedding_complete.done 이 없습니다. 먼저 `embed.py` 를 실행하세요.")
+        return
+
+    # 2) 벡터 로딩
+    vec_files = sorted(out.glob("vecs_gpu*.npy"))
+    if not vec_files:
+        print("❌ vecs_gpu*.npy 파일을 찾을 수 없습니다.")
+        return
+
+    print("[INDEX] 벡터 로딩 중…")
+    mats = [np.load(p, mmap_mode="r") for p in vec_files]
+    X = np.vstack(mats).astype("float32")
+    num_vec, dim = X.shape
+    print(f"[INDEX] 총 {num_vec:,}개 벡터, 차원 {dim}")
+
+    # 3) nlist 조정 (옵션값 또는 √N)
+    eff_nlist = min(args.nlist, max(1, int(np.sqrt(num_vec))))
+    print(f"[INDEX] effective nlist: {eff_nlist} (requested {args.nlist})")
+
+    # 4) 샘플링 기반 train
+    train_size = min(num_vec, max(MIN_TRAIN_VECS, MAX_SAMPLE_VECS))
+    if num_vec > train_size:
+        np.random.seed(1234)
+        perm = np.random.permutation(num_vec)[:train_size]
+        train_vecs = X[perm]
+        print(f"[INDEX] train 용 샘플링 벡터: {train_size:,}/{num_vec:,}")
+    else:
+        train_vecs = X
+        print(f"[INDEX] train 용 벡터: 전체 사용 ({num_vec:,})")
+
+    # 5) 인덱스 팩토리 스트링 구성 (중복 없이)
+    parts = []
+    # OPQ
+    parts.append("OPQ16")
+    # IVF + HNSW (언더스코어로 결합)
+    ivf_part = f"IVF{eff_nlist}"
+    if not args.no_hnsw:
+        ivf_part += f"_HNSW{HNSW_M}"
+    parts.append(ivf_part)
+    # PQ
+    parts.append(f"PQ{args.pq_bytes}")
+
+    factory_str = ",".join(parts)
+    print(f"[INDEX] index_factory: {factory_str}")
+
+    # 6) CPU 인덱스 생성
+    idx_cpu = faiss.index_factory(dim, factory_str)
+    idx_cpu.nprobe = args.nprobe
+
+    # 7) (선택) GPU 리소스
+    if args.use_gpu:
+        print("[INDEX] GPU 리소스 확보 및 CPU→GPU 인덱스 복사 (단일 GPU)")
+        # 1) GPU 리소스 초기화
+        res = faiss.StandardGpuResources()
+        # 2) 복제 옵션 설정 (CPU 코어스 퀀타이저 폴백 허용)
+        co = faiss.GpuClonerOptions()
+        co.allowCpuCoarseQuantizer = True
+        # 3) GPU 0번에만 인덱스 복제
+        idx = faiss.index_cpu_to_gpu(res, 0, idx_cpu, co)
+    else:
+        idx = idx_cpu
+
+    # 8) train → add
+    print(f"[INDEX] train 시작 (n={len(train_vecs):,})")
+    idx.train(train_vecs)
+    print("[INDEX] add 시작")
+    idx.add(X)
+
+    # 9) GPU→CPU 인덱스 복원
+    if args.use_gpu:
+        print("[INDEX] GPU→CPU 인덱스 복원")
+        idx_cpu = faiss.index_gpu_to_cpu(idx)
+
+    # 10) 저장
+    out_path = out/"index_cpu.faiss"
+    print(f"[INDEX] index 저장 → {out_path}")
+    faiss.write_index(idx_cpu, str(out_path))
+
+    print("[INDEX] 완료!")
+
+if __name__=="__main__":
+    warnings.filterwarnings("ignore")
+    main()

--- a/RAG/embed.py
+++ b/RAG/embed.py
@@ -1,0 +1,227 @@
+#!/usr/bin/env python
+# embed_with_eta.py
+"""
+JSONL → 문장 단위 청크 → GPU별 임베딩
+- 중간 종료 시 재시작(resume) 지원
+- KSS로 한글 문장 분리, MAX_LEN 초과 시 슬라이딩 윈도우
+- tqdm으로 개별 GPU 속도(it/s) 기반 남은 ETA 가늠
+- 성공 시 out_dir/embedding_complete.done 생성
+"""
+import os, json, argparse, warnings, time
+from pathlib import Path
+from typing import List
+
+import numpy as np
+import torch
+from torch.multiprocessing import spawn
+from sentence_transformers import SentenceTransformer
+from transformers import AutoTokenizer
+from tqdm import tqdm
+import kss  # Korean Sentence Splitter
+# import mecab
+
+# ──────────────── 파라미터 ────────────────
+EMBED_MODEL  = "BAAI/bge-m3"
+MAX_LEN      = 2048
+STRIDE       = 512
+CHKPT_EVERY  = 1000  # 청크 단위로 체크포인트
+
+os.environ["TOKENIZERS_PARALLELISM"] = "false"
+torch.backends.cudnn.benchmark = True
+
+# ──────────────── 청크 유틸 ────────────────
+from transformers import PreTrainedTokenizer
+
+def split_paragraphs(text: str) -> List[str]:
+    paras = [p.strip() for p in text.split("\n\n") if p.strip()]
+    return paras or [text]
+
+def slide_if_needed(text: str, tokenizer: PreTrainedTokenizer) -> List[str]:
+    ids = tokenizer.encode(text, add_special_tokens=False)
+    if len(ids) <= MAX_LEN:
+        return [text]
+    chunks = []
+    for i in range(0, len(ids), STRIDE):
+        seg = ids[i:i+MAX_LEN]
+        if not seg:
+            break
+        chunks.append(tokenizer.decode(seg, skip_special_tokens=True))
+        if len(seg) < MAX_LEN:
+            break
+    return chunks
+
+def chunk_by_sentences(text: str, tokenizer: PreTrainedTokenizer) -> List[str]:
+    ids = tokenizer.encode(text, add_special_tokens=False)
+    try:
+        sents = kss.split_sentences(text)
+    except Exception:
+        sents = [text]
+    chunks, current = [], ""
+    for sent in sents:
+        combined = (current + " " + sent).strip()
+        tok_comb = tokenizer.encode(combined, add_special_tokens=False)
+        if len(tok_comb) <= MAX_LEN:
+            current = combined
+        else:
+            if current:
+                chunks.append(current)
+            # 문장 자체가 너무 길면 슬라이드
+            if len(tokenizer.encode(sent, add_special_tokens=False)) > MAX_LEN:
+                chunks.extend(slide_if_needed(sent, tokenizer))
+                current = ""
+            else:
+                current = sent
+    if current:
+        chunks.append(current)
+    return chunks
+
+def append_numpy(path: Path, arr: np.ndarray):
+    if arr.size == 0:
+        return
+    if not path.exists():
+        np.save(path, arr)
+    else:
+        old = np.load(path, mmap_mode="r")
+        mp = np.lib.format.open_memmap(str(path),
+    mode='w+', dtype='float32',
+    shape=(total_chunks, dim))
+        # chunk 단위로
+        mp[offset:offset+len(arr)] = arr
+
+
+# ──────────────── 워커 ────────────────
+@torch.no_grad()
+def worker(rank: int, world: int, files: List[Path], args):
+    start = time.time()
+    device = f"cuda:{rank}" if torch.cuda.is_available() else "cpu"
+    print(f"[GPU{rank}] Start on {device}")
+
+    # 모델/토크나이저
+    model     = SentenceTransformer(args.model, device=device)
+    model.eval()
+    tokenizer = AutoTokenizer.from_pretrained(args.model)
+    tokenizer.model_max_length = MAX_LEN * 10
+    warnings.filterwarnings("ignore", category=UserWarning, module="faiss")
+
+    out_dir   = Path(args.out_dir); out_dir.mkdir(parents=True, exist_ok=True)
+    vec_file  = out_dir / f"vecs_gpu{rank}.npy"
+    meta_file = out_dir / f"meta_gpu{rank}.jsonl"
+
+    # # ── resume 로직 ──
+    resume = 0
+    # if vec_file.exists() and meta_file.exists():
+    #     resume = np.load(vec_file, mmap_mode="r").shape[0]
+    #     if sum(1 for _ in meta_file.open()) != resume:
+    #         print(f"[GPU{rank}] vec/meta 불일치 → reset resume")
+    #         resume = 0
+    #     else:
+    #         print(f"[GPU{rank}] resume from {resume}")
+
+    # tqdm: 총량 미지정, 속도(it/s) 기반 ETA 가늠
+    pbar = tqdm(desc=f"GPU{rank}", position=rank, unit="chunk", total=None)
+    pbar.update(resume)
+
+    buf_vec, buf_meta = [], []
+    idx_global = skip = processed = 0
+
+    for path in files:
+        fname = path.name
+        if "guide" in fname.lower():
+            txt_key, meta_keys, typ = "text", ["id","source","gubun"], "guide"
+        elif "laws" in fname.lower():
+            txt_key, meta_keys, typ = "output", ["input"], "law"
+        else:
+            txt_key, meta_keys, typ = "content", ["patent_id","section","subsection","claim_number","paragraph"], "patent"
+
+        for ln in path.open(encoding="utf-8"):
+            # 분산 처리 분기
+            if idx_global % world != rank:
+                idx_global += 1
+                continue
+            idx_global += 1
+            if skip < resume:
+                skip += 1
+                continue
+
+            try:
+                obj = json.loads(ln, strict=False)
+            except json.JSONDecodeError:
+                continue
+            if typ == "patent" and obj.get("section") == "특허_기본정보":
+                continue
+
+            content = obj.get(txt_key)
+            if not content or isinstance(content, dict):
+                continue
+            txt = str(content).strip()
+            if not txt:
+                continue
+
+            base = {"type": typ, "source_file": fname}
+            for k in meta_keys:
+                if k in obj:
+                    base[k] = obj[k]
+
+            for para in split_paragraphs(txt):
+                for chunk in chunk_by_sentences(para, tokenizer):
+                    emb = model.encode(
+                        [chunk],
+                        convert_to_numpy=True,
+                        normalize_embeddings=True,
+                    )
+                    buf_vec.append(emb.astype("float32"))
+
+                    meta = base.copy()
+                    meta["text"] = chunk
+                    buf_meta.append(json.dumps(meta, ensure_ascii=False) + "\n")
+
+                    processed += 1
+                    pbar.update(1)
+
+                    if processed % CHKPT_EVERY == 0:
+                        numpy.lib.format.open_memmap
+                        #append_numpy(vec_file, np.vstack(buf_vec))
+                        with meta_file.open("a", encoding="utf-8") as mf:
+                            mf.writelines(buf_meta)
+                        buf_vec.clear(); buf_meta.clear()
+                        elapsed = time.time() - start
+                        speed = processed / elapsed
+                        print(f"[GPU{rank}] checkpoint +{processed} chunks | {speed:.2f} it/s")
+
+    # 마지막 flush
+    if buf_vec:
+        numpy.lib.format.open_memmap
+        #append_numpy(vec_file, np.vstack(buf_vec))
+        with meta_file.open("a", encoding="utf-8") as mf:
+            mf.writelines(buf_meta)
+
+    pbar.close()
+    elapsed = time.time() - start
+    avg_speed = processed / elapsed if elapsed > 0 else 0
+    print(f"[GPU{rank}] done – 추가 {processed} chunks, elapsed {elapsed:.1f}s, avg {avg_speed:.2f} it/s")
+
+# ──────────────── Main ────────────────
+def main():
+
+    if meta_file.exists():
+        meta_file.unlink()
+
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--data_dir", default="data")
+    ap.add_argument("--out_dir",  default="finaldb")
+    ap.add_argument("--model",    default=EMBED_MODEL)
+    ap.add_argument("--gpus",     type=int, default=torch.cuda.device_count())
+    args = ap.parse_args()
+
+    files = sorted(Path(args.data_dir).glob("*.jsonl"))
+    print(f"Files: {len(files)} | GPUs: {args.gpus}")
+
+    start_all = time.time()
+    spawn(worker, args=(args.gpus, files, args), nprocs=args.gpus, join=True)
+    total_elapsed = time.time() - start_all
+    print(f"[MASTER] 전체 elapsed {total_elapsed:.1f}s")
+
+    Path(args.out_dir, "embedding_complete.done").write_text("")
+
+if __name__ == "__main__":
+    main()

--- a/RAG/rag (5).py
+++ b/RAG/rag (5).py
@@ -1,0 +1,267 @@
+#!/usr/bin/env python
+"""multi_gpu_rag.py (refactored v3)
+──────────────────────────────────────────────────────────────────────
+✓  JSONL 파일별로 ‘텍스트 필드’만 청크화, 나머지는 메타데이터로만 보존  
+✓  문단 단위 분리 후 MAX_LEN 초과 시에만 슬라이딩 윈도우 적용  
+✓  특허·법령·가이드·규칙 등 파일 유형별 텍스트 필드/메타 필드 자동 처리  
+✓  CHKPT_EVERY 청크마다 GPU별 NumPy 체크포인트 → 중도종료 안전  
+✓  완료 후 vecs 병합 및 IVF-OPQ-PQ 인덱스 빌드  
+"""
+from __future__ import annotations
+import os, json, argparse, warnings
+from pathlib import Path
+from typing import List, Dict
+
+import numpy as np
+import faiss, torch
+from torch.multiprocessing import spawn
+from sentence_transformers import SentenceTransformer
+from transformers import AutoTokenizer
+from tqdm import tqdm
+import nltk
+from nltk.tokenize import sent_tokenize
+
+# 워커 프로세스가 시작될 때 한 번만 실행되도록
+nltk.download('punkt', quiet=True)
+nltk.download("punkt_tab", quiet=True)
+
+# ──────────────── 파라미터 ────────────────
+EMBED_MODEL  = "BAAI/bge-m3"
+MAX_LEN      = 2048
+STRIDE       = 512
+CHKPT_EVERY  = 1_000
+MIN_TRAIN    = 2_500
+N_LIST       = 512
+PQ_BYTES     = 64
+NPROBE       = 32
+
+os.environ["TOKENIZERS_PARALLELISM"] = "false"
+torch.backends.cudnn.benchmark = True
+
+# ──────────────── 청크 유틸 ────────────────
+def split_paragraphs(text: str) -> List[str]:
+    paras = [p.strip() for p in text.split("\n\n") if p.strip()]
+    return paras or [text]
+
+def chunk_by_sentences(text: str, tokenizer) -> List[str]:
+    sents = sent_tokenize(text)
+    chunks = []
+    current = ""
+    for sent in sents:
+        # 현재 청크에 이 문장을 붙였을 때 토큰 수
+        tokens = tokenizer.encode((current + " " + sent).strip(), add_special_tokens=False)
+        if len(tokens) <= MAX_LEN:
+            # 문제 없으면 합치기
+            current = (current + " " + sent).strip()
+        else:
+            # 현재 청크를 확정
+            if current:
+                chunks.append(current)
+            # 이 문장 자체가 너무 길면 슬라이드 윈도우
+            if len(tokenizer.encode(sent, add_special_tokens=False)) > MAX_LEN:
+                chunks.extend(slide_if_needed(sent, tokenizer))
+                current = ""
+            else:
+                current = sent
+    # 마지막 남은 문장
+    if current:
+        chunks.append(current)
+    return chunks
+
+def slide_if_needed(text: str, tokenizer) -> List[str]:
+    ids = tokenizer.encode(text, add_special_tokens=False)
+    if len(ids) <= MAX_LEN:
+        return [text]
+    chunks = []
+    for i in range(0, len(ids), STRIDE):
+        seg = ids[i:i + MAX_LEN]
+        if not seg: break
+        chunks.append(tokenizer.decode(seg, skip_special_tokens=True))
+        if len(seg) < MAX_LEN: break
+    return chunks
+
+def append_numpy(path: Path, arr: np.ndarray):
+    if arr.size == 0: return
+    if not path.exists():
+        np.save(path, arr)
+    else:
+        old = np.load(path, mmap_mode="r")
+        np.save(path, np.vstack((old, arr)))
+
+# ──────────────── 워커 프로세스 ────────────────
+@torch.no_grad()
+def worker(rank: int, world: int, files: List[Path], args):
+    device = f"cuda:{rank}" if torch.cuda.is_available() else "cpu"
+    print(f"[GPU{rank}] Start on {device}")
+
+    # 모델/토크나이저
+    model     = SentenceTransformer(args.model, device=device)
+    model.eval()
+    tokenizer = AutoTokenizer.from_pretrained(args.model)
+    tokenizer.model_max_length = 10_000
+    warnings.filterwarnings("ignore", category=UserWarning, module="faiss")
+
+    out_dir   = Path(args.out_dir)
+    out_dir.mkdir(parents=True, exist_ok=True)
+    vec_file  = out_dir / f"vecs_gpu{rank}.npy"
+    meta_file = out_dir / f"meta_gpu{rank}.jsonl"
+
+    # 특허 기본정보만 뽑아두기
+    patent_basic: Dict[str, Dict] = {}
+    for p in files:
+        if p.name.startswith("patents") or p.name.startswith("patent_basic"):
+            for ln in p.open(encoding="utf-8"):
+                obj = json.loads(ln, strict=False)
+                if obj.get("section") == "특허_기본정보":
+                    patent_basic[obj.get("patent_id","")] = obj.get("content", {})
+
+    # 기존 체크포인트 복구
+    done = 0
+    if vec_file.exists() and meta_file.exists():
+        done = np.load(vec_file, mmap_mode="r").shape[0]
+        if done != sum(1 for _ in meta_file.open()):
+            print(f"[GPU{rank}] vec/meta 불일치 → 리셋")
+            done = 0
+    if done:
+        print(f"[GPU{rank}] resume at {done:,} chunks")
+
+    buf_vec, buf_meta = [], []
+    idx_global, skipped = 0, 0
+    pbar = tqdm(desc=f"GPU{rank}", position=rank, leave=False)
+
+    for path in files:
+        fname = path.name
+        # 파일 유형별 청크 전략 정의
+        if "guide" in fname.lower():        # 심사실무가이드
+            txt_key, meta_keys, typ = "text", ["id","source","gubun"], "guide"
+        elif "laws" in fname.lower():       # 법령 정의 파일
+            txt_key, meta_keys, typ = "output", ["input"], "law"
+        else:                                # 특허 JSONL
+            txt_key, meta_keys, typ = "content", ["patent_id","section","subsection","claim_number","paragraph"], "patent"
+
+        for ln in path.open(encoding="utf-8"):
+            if (idx_global % world) != rank:
+                idx_global += 1
+                continue
+            idx_global += 1
+            if skipped < done:
+                skipped += 1
+                continue
+
+            item = json.loads(ln, strict=False)
+            # 특허 기본정보는 메타로만 쓰고 청크 건너뜀
+            if typ=="patent" and item.get("section")=="특허_기본정보":
+                continue
+
+            # 텍스트 추출 (딕셔너리면 값으로, 문자열이면 그대로)
+            content = item.get(txt_key)
+            if isinstance(content, dict):
+                # e.g. 특허 기본정보가 dict일 경우는 이미 skip 했으니 패스
+                continue
+            txt = str(content or "").strip()
+            if not txt:
+                continue
+
+            # 메타 구성
+            base = {"type": typ, "source_file": fname}
+            for k in meta_keys:
+                if k in item:
+                    base[k] = item[k]
+            # 특허의 경우, 추가 메타(상태, 발명의 명칭)
+            if typ=="patent":
+                info = patent_basic.get(item.get("patent_id",""), {})
+                base["status"]        = info.get("상태","")
+                base["발명의_명칭"]    = info.get("발명의 명칭","")
+
+            # 문단 분리 + 슬라이드
+            # 문단 단위로 분리 → 필요할 때만 슬라이드 윈도우
+            for para in split_paragraphs(txt):
+                for chunk in chunk_by_sentences(para, tokenizer):
+                    emb = model.encode([chunk],
+                                       convert_to_numpy=True,
+                                       normalize_embeddings=True)
+                    buf_vec.append(emb.astype("float32"))
+            
+                    m = base.copy()
+                    m["text"] = chunk
+                    buf_meta.append(json.dumps(m, ensure_ascii=False) + "\n")
+            
+                    pbar.update(1)
+            
+                    # 체크포인트
+                    if len(buf_vec) >= CHKPT_EVERY:
+                        append_numpy(vec_file, np.vstack(buf_vec))
+                        with meta_file.open("a", encoding="utf-8") as mf:
+                            mf.writelines(buf_meta)
+                        done += len(buf_vec)
+                        print(f"[GPU{rank}] checkpoint {done:,} chunks")
+                        buf_vec.clear()
+                        buf_meta.clear()
+
+
+    # 마지막 flush
+    if buf_vec:
+        append_numpy(vec_file, np.vstack(buf_vec))
+        with meta_file.open("a", encoding="utf-8") as mf:
+            mf.writelines(buf_meta)
+        done += len(buf_vec)
+    pbar.close()
+    print(f"[GPU{rank}] done – {done:,} chunks")
+
+# ──────────────── 마스터 인덱스 빌드 ────────────────
+def build_master_index(out_dir: str):
+    print("[MASTER] build index")
+    out = Path(out_dir)
+    mats = [np.load(p, mmap_mode="r") for p in sorted(out.glob("vecs_gpu*.npy"))]
+    X   = np.vstack(mats)
+    dim = X.shape[1]
+
+    # --- (B) 데이터에 맞춰 클러스터 수 조정 ---
+    num_vec    = len(X)
+    max_nlist  = max(1, num_vec // 20)
+    eff_nlist  = min(N_LIST, max_nlist)
+    print(f"[MASTER] effective nlist: {eff_nlist} (original {N_LIST}), total vectors: {num_vec:,}")
+
+    idx = faiss.index_factory(dim, f"OPQ16_{PQ_BYTES},IVF{eff_nlist},PQ{PQ_BYTES}")
+    idx.nprobe = NPROBE
+
+    # --- (A) 충분한 학습용 벡터 사용 ---
+    print(f"[MASTER] training on {num_vec:,} vectors")
+    idx.train(X)
+
+    idx.add(X)
+    # 문자열 경로로 저장
+    faiss.write_index(idx, str(out/"index_cpu.faiss"))
+    print(f"[MASTER] index_cpu.faiss with {len(X):,} vectors")
+
+    # 메타 합치기
+    with (out/"metadata.jsonl").open("w", encoding="utf-8") as wf:
+        for mf in sorted(out.glob("meta_gpu*.jsonl")):
+            wf.write(mf.read_text(encoding="utf-8"))
+    print("[MASTER] metadata.jsonl saved")
+
+    # GPU 인덱스
+    try:
+        res     = faiss.StandardGpuResources()
+        gpu_idx = faiss.index_cpu_to_gpu(res, 0, idx)
+        print("[MASTER] GPU index ready")
+    except Exception as e:
+        print("[MASTER] GPU index failed:", e)
+
+
+# ──────────────── Main ────────────────
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--data_dir", default="data")
+    ap.add_argument("--out_dir",  default="newvectordb")
+    ap.add_argument("--model",    default=EMBED_MODEL)
+    ap.add_argument("--gpus",     type=int, default=torch.cuda.device_count())
+    args = ap.parse_args()
+
+    files = sorted(Path(args.data_dir).glob("*.jsonl"))
+    print(f"Files: {len(files)} | GPUs: {args.gpus}")
+    spawn(worker, args=(args.gpus, files, args), nprocs=args.gpus, join=True)
+    build_master_index(args.out_dir)
+
+if __name__=="__main__":
+    main()

--- a/RAG/test (2).py
+++ b/RAG/test (2).py
@@ -1,0 +1,141 @@
+import json
+import faiss
+import numpy as np
+from sentence_transformers import SentenceTransformer, CrossEncoder
+
+# ────────────────────────────────────────────────
+# 설정
+# ────────────────────────────────────────────────
+EMBED_MODEL   = "BAAI/bge-m3"
+RERANK_MODEL  = "cross-encoder/ms-marco-MiniLM-L-6-v2"
+INDEX_PATH    = "embeddb/index_cpu.faiss"
+META_PATH     = "embeddb/metadata.jsonl"
+
+# 1차 FAISS 검색 시도할 top_n, rerank할 rerank_n
+TOP_K         = 5
+INITIAL_K     = 50    # first-pass FAISS 에서 뽑아올 개수
+NP            = 64    # IVF.nprobe
+
+# ────────────────────────────────────────────────
+# 1. 모델 & 인덱스 로드
+# ────────────────────────────────────────────────
+print("🔄  로드 중…")
+embedder    = SentenceTransformer(EMBED_MODEL, device="cpu")
+reranker    = CrossEncoder(RERANK_MODEL, device="cpu")
+index       = faiss.read_index(INDEX_PATH)
+index.nprobe = NP
+
+# 메타 전체를 미리 읽어 두면 빠릅니다
+with open(META_PATH, encoding="utf-8") as f:
+    metas = [json.loads(line) for line in f]
+
+print(f"✅  인덱스 로드 완료: {index.ntotal} vectors, nprobe={NP}")
+print("메타 데이터 개수:", len(metas))
+
+
+# ────────────────────────────────────────────────
+# 2. 검색+리랭크 함수
+# ────────────────────────────────────────────────
+def search_and_rerank(query: str, top_k: int = TOP_K, init_k: int = INITIAL_K):
+    # 1) 쿼리 임베딩
+    qv = embedder.encode([query], normalize_embeddings=True).astype(np.float32)
+
+    # 2) FAISS 검색
+    D0, I0 = index.search(qv, init_k)
+    idxs0 = I0[0].tolist()
+
+    # 3) Cross-Encoder rerank
+    rerank_inputs = [(query, metas[i]['content']) for i in idxs0]
+    scores_rerank = reranker.predict(rerank_inputs)
+    # 정렬
+    reranked = sorted(zip(idxs0, scores_rerank), key=lambda x: x[1], reverse=True)[:top_k]
+
+    # 4) 결과
+    results = []
+    for idx, sc in reranked:
+        meta = metas[idx].copy()
+        results.append((float(sc), meta))
+    return results
+
+# ────────────────────────────────────────────────
+# 3. 대화형 테스트
+# ────────────────────────────────────────────────
+if __name__ == "__main__":
+    print("🎯 검색 테스트—원하는 문장을 입력하고 엔터를 눌러 보세요. 빈 입력 시 종료합니다.")
+    while True:
+        query = input("\n검색어 ▶ ").strip()
+        if not query:
+            print("종료합니다.")
+            break
+
+        hits = search_and_rerank(query)
+        print(f"\n🔍 Top-{len(hits)} 결과:")
+        for rank, (score, meta) in enumerate(hits, start=1):
+            print(f"\n{rank:>2}. score={score:.4f}")
+            print(f"   • source_file: {meta['source_file']}")
+            print(f"   • type       : {meta['type']}")
+            if meta['type']=="특허":
+                print(f"   • patent_id  : {meta['patent_id']}")
+                print(f"   • section    : {meta['section']} / {meta['subsection']}")
+                print(f"   • claim#     : {meta['claim_number']}")
+                print(f"   • status     : {meta['status']}")
+            print(f"   • title      : {meta.get('발명의_명칭','')}")
+            print(f"   • content    : {meta['content'][:200]}...")  # 앞 200자만
+
+
+
+import faiss
+import numpy as np
+from sentence_transformers import SentenceTransformer
+from transformers import AutoTokenizer, AutoModelForSequenceClassification
+import torch
+
+# 1) FAISS 인덱스 로드
+index = faiss.read_index("embeddb/index_cpu.faiss")
+index.nprobe = 64  # 검색 속도/정확도 밸런스
+
+# 2) Bi-Encoder (BGE-M3) 모델 로드
+be_model = SentenceTransformer("BAAI/bge-m3", device="cuda")
+be_model.eval()
+
+# 3) Cross-Encoder 모델 로드
+ce_tokenizer = AutoTokenizer.from_pretrained("cross-encoder/ms-marco-MiniLM-L-12-v2")
+ce_model     = AutoModelForSequenceClassification.from_pretrained("cross-encoder/ms-marco-MiniLM-L-12-v2")
+ce_model.to("cuda").eval()
+
+def retrieve_and_rerank(query: str,
+                        top_k_faiss: int = 100,
+                        top_n_final: int = 10):
+    # (1) Bi-Encoder 임베딩
+    q_emb = be_model.encode([query], convert_to_numpy=True, normalize_embeddings=True)
+    # (2) FAISS 검색
+    D, I = index.search(q_emb, top_k_faiss)  # distances, indices
+
+    # (3) 후보 문장들 로드
+    #    — 미리 meta_gpu*.jsonl 에서 line 단위로 읽어서 배열로 메모리에 캐시해 두세요
+    #    meta_lines[i] = 검색 결과 i번 벡터의 원문 텍스트
+    candidates = [ meta_lines[idx] for idx in I[0] ]
+
+    # (4) Cross-Encoder 재순위
+    inputs = ce_tokenizer(
+        [query]*len(candidates),
+        candidates,
+        padding=True, truncation=True, return_tensors="pt"
+    ).to("cuda")
+    with torch.no_grad():
+        scores = ce_model(**inputs).logits.squeeze(-1)  # [batch]
+    topk = torch.topk(scores, k=top_n_final)
+
+    return [(candidates[i], float(scores[i])) for i in topk.indices.cpu().numpy()]
+
+# 사용 예
+if __name__ == "__main__":
+    # — 미리 메타 로드
+    with open("embeddb/meta_all.jsonl", encoding="utf-8") as f:
+        meta_lines = [json.loads(l)["text"] for l in f]
+
+    query = "인공지능 기반 안구질병 진단 방법"
+    results = retrieve_and_rerank(query, top_k_faiss=200, top_n_final=5)
+    for text, score in results:
+        print(f"{score:.3f}\t{text}")
+


### PR DESCRIPTION
## 📌 PR 제목
[FEAT] RAG 인덱스 빌드 및 메타데이터 통합 스크립트 추가

## 변경 사항
- JSONL 데이터를 GPU별로 청크 단위 임베딩하고, `meta_gpu*.jsonl` 샤드 파일을 생성하도록 구현  
- GPU 샤드 메타파일(`meta_gpu*.jsonl`)을 숫자 순서대로 머지하여 `metadata.jsonl` 생성  
- FAISS OPQ+IVF+HNSW+PQ 인덱스 빌드 스크립트 추가 (`--use_gpu` 옵션 지원, CPU 폴백 허용)  
- 생성된 인덱스와 메타데이터를 로드하여 검색·재랭킹 기능 확인용 샘플 테스트 구현  

## 테스트
- [x] 로컬에서 임베딩 → 메타 머지 → 인덱스 빌드 → 검색 테스트 시나리오 전부 정상 동작 확인  
- [x] 기존 테스트 통과  
- [ ] 새로운 테스트 코드 추가 (검색 정확도 · 대량 처리 성능 테스트 예정)

## 관련 이슈
Closes #42

## 기타
- `merge_meta.py` 실행 후 메타라인 수(`wc -l metadata.jsonl`)와 FAISS 인덱스 벡터 수(`index.ntotal`)가 일치하는지 꼭 확인 필요  
- CPU 모드만 사용해도 동작하나, GPU 모드로 빌드 및 검색 성능 가속 가능

반드시 아래 순서로 환경을 설정해야 합니다. 

# ① Miniconda 스크립트 다운로드
curl -sS https://repo.anaconda.com/miniconda/Miniconda3-py310_24.1.2-0-Linux-x86_64.sh -o /tmp/mc.sh

# ② 무(無)프롬프트 설치
bash /tmp/mc.sh -b -p /opt/conda

# ③ conda 명령을 현재 셸에 등록
eval "$(/opt/conda/bin/conda shell.bash hook)"

conda create -y -n rag python=3.10
conda activate rag          # <— 매 세션마다 필요!

# 3-1) GPU Faiss + cuVS (CUDA 11.8 빌드)
conda install -y -c pytorch -c nvidia -c rapidsai -c conda-forge \
               libnvjitlink faiss-gpu-cuvs=1.11.0

# 3-2) NLP / RAG 스택
pip install sentence-transformers==2.7.0 \
            transformers==4.43.0 accelerate tqdm

# (선택) Flash-Attention 2 사전 빌드 휠
pip install flash-attn --no-build-isolation || true

python - <<'PY'
import torch, faiss
print("Torch :", torch.__version__, "| CUDA", torch.version.cuda)
print("Faiss :", faiss.__version__,  "| GPUs", faiss.get_num_gpus())
PY

---

### 체크리스트
- [x] 코드가 깔끔하게 작성되었나요?  
- [x] 문서화는 충분히 되었나요? (스크립트 상단 docstring 포함)  
- [x] 불필요한 커밋/파일은 제거되었나요?  

---

### 리뷰어에게 바라는 점
- 디렉토리 구조(`scripts/`, `embeddb/`, `finaldb/` 등)가 적절한지 확인 부탁드립니다.  
- 스크립트 실행 순서 및 옵션 설명이 README에 충분한지 피드백 부탁드립니다.

감사합니다!
